### PR TITLE
Bump `infection/infection` from `0.30.0` to `0.30.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "~5.0.1",
-        "infection/infection": "~0.30.0",
+        "infection/infection": "~0.30.1",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.5",
         "vimeo/psalm": "~6.12.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a4edb4f6005303c614f790e89ead0aca",
+    "content-hash": "ec6b75176d5660c53b5320b3169bdac2",
     "packages": [],
     "packages-dev": [
         {
@@ -2529,16 +2529,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.30.0",
+            "version": "0.30.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "fa3be5667a312e108a81425660a847710cd36632"
+                "reference": "70cd94675f6372cf13962d9d52de86b02a909c09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/fa3be5667a312e108a81425660a847710cd36632",
-                "reference": "fa3be5667a312e108a81425660a847710cd36632",
+                "url": "https://api.github.com/repos/infection/infection/zipball/70cd94675f6372cf13962d9d52de86b02a909c09",
+                "reference": "70cd94675f6372cf13962d9d52de86b02a909c09",
                 "shasum": ""
             },
             "require": {
@@ -2643,7 +2643,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.30.0"
+                "source": "https://github.com/infection/infection/tree/0.30.1"
             },
             "funding": [
                 {
@@ -2655,7 +2655,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-07-02T22:08:45+00:00"
+            "time": "2025-07-03T22:10:25+00:00"
         },
         {
             "name": "infection/mutator",


### PR DESCRIPTION
Bumps `infection/infection` from `0.30.0` to `0.30.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`