### PR TITLE
Bump `infection/infection` from `0.30.1` to `0.30.2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "~5.0.1",
-        "infection/infection": "~0.30.1",
+        "infection/infection": "~0.30.2",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.6",
         "vimeo/psalm": "~6.12.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ffec165de2c56ae8db8ce11cdc243d8",
+    "content-hash": "fa8bcd866d9f8780fd7606904893b365",
     "packages": [],
     "packages-dev": [
         {
@@ -2529,16 +2529,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.30.1",
+            "version": "0.30.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "70cd94675f6372cf13962d9d52de86b02a909c09"
+                "reference": "edff4c9aaf0bdb2a6f36fffb2fb7672597818612"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/70cd94675f6372cf13962d9d52de86b02a909c09",
-                "reference": "70cd94675f6372cf13962d9d52de86b02a909c09",
+                "url": "https://api.github.com/repos/infection/infection/zipball/edff4c9aaf0bdb2a6f36fffb2fb7672597818612",
+                "reference": "edff4c9aaf0bdb2a6f36fffb2fb7672597818612",
                 "shasum": ""
             },
             "require": {
@@ -2570,8 +2570,7 @@
             },
             "conflict": {
                 "antecedent/patchwork": "<2.1.25",
-                "dg/bypass-finals": "<1.4.1",
-                "phpunit/php-code-coverage": ">9,<9.1.4 || >9.2.17,<9.2.21"
+                "dg/bypass-finals": "<1.4.1"
             },
             "require-dev": {
                 "ext-simplexml": "*",
@@ -2643,7 +2642,7 @@
             ],
             "support": {
                 "issues": "https://github.com/infection/infection/issues",
-                "source": "https://github.com/infection/infection/tree/0.30.1"
+                "source": "https://github.com/infection/infection/tree/0.30.2"
             },
             "funding": [
                 {
@@ -2655,7 +2654,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2025-07-03T22:10:25+00:00"
+            "time": "2025-07-09T23:00:20+00:00"
         },
         {
             "name": "infection/mutator",


### PR DESCRIPTION
Bumps `infection/infection` from `0.30.1` to `0.30.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`