### PR TITLE
Bump `vimeo/psalm` from `6.12.1` to `6.13.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.2.7",
         "symfony/var-dumper": "~7.3.1",
-        "vimeo/psalm": "~6.12.1"
+        "vimeo/psalm": "~6.13.0"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4989bfd55c8f46f89b7d44c210f5aa01",
+    "content-hash": "c12731fe371dafe5934c35370bb6729c",
     "packages": [],
     "packages-dev": [
         {
@@ -7239,16 +7239,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.12.1",
+            "version": "6.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f"
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/e71404b0465be25cf7f8a631b298c01c5ddd864f",
-                "reference": "e71404b0465be25cf7f8a631b298c01c5ddd864f",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/70cdf647255a1362b426bb0f522a85817b8c791c",
+                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c",
                 "shasum": ""
             },
             "require": {
@@ -7353,7 +7353,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-07-04T09:56:28+00:00"
+            "time": "2025-07-14T09:59:17+00:00"
         },
         {
             "name": "webmozart/assert",


### PR DESCRIPTION
Bumps `vimeo/psalm` from `6.12.1` to `6.13.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`