### PR TITLE
Bump `php` from `~8.4.0` to `~8.4.0 || ~8.5.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "#StopGenocide"
     ],
     "require": {
-        "php": "~8.4.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be580948ecf094d9a1f00606e4dc709e",
+    "content-hash": "2f6d9e7ce0a5d87200c0f66dbbb6041f",
     "packages": [],
     "packages-dev": [
         {
@@ -6897,7 +6897,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.4.0",
+        "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*"
     },
     "platform-dev": {


### PR DESCRIPTION
Bumps `php` from `~8.4.0` to `~8.4.0 || ~8.5.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`