### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1808,12 +1808,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "630150015b4334fe9c622cb3522b049ef205d44f"
+                "reference": "7f141b119721d61069156042d3dd3402087d8938"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/630150015b4334fe9c622cb3522b049ef205d44f",
-                "reference": "630150015b4334fe9c622cb3522b049ef205d44f",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7f141b119721d61069156042d3dd3402087d8938",
+                "reference": "7f141b119721d61069156042d3dd3402087d8938",
                 "shasum": ""
             },
             "require": {
@@ -1970,7 +1970,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-24T12:36:48+00:00"
+            "time": "2025-08-24T15:04:20+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main`.

This pull request changes the following file(s): 

- Update `composer.lock`