### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#b41b8c9`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1800,12 +1800,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "025d1d15b3d612deda2ff7d026afa6f7f1379411"
+                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/025d1d15b3d612deda2ff7d026afa6f7f1379411",
-                "reference": "025d1d15b3d612deda2ff7d026afa6f7f1379411",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/b41b8c9261587c68541e6bf38933426ce8b9c8db",
+                "reference": "b41b8c9261587c68541e6bf38933426ce8b9c8db",
                 "shasum": ""
             },
             "require": {
@@ -1962,7 +1962,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-09-11T16:38:56+00:00"
+            "time": "2025-09-11T17:06:16+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#025d1d1` to `dev-main#b41b8c9`.

This pull request changes the following file(s): 

- Update `composer.lock`