### PR TITLE
Update ghostwriter/container to version 6.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     "require-dev": {
         "ext-xdebug": "*",
         "ghostwriter/coding-standard": "dev-main",
-        "ghostwriter/container": "^6.0.1",
+        "ghostwriter/container": "^6.1.0",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.3",
         "symfony/var-dumper": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb0072f4c194bddc9f0825daf5c50e95",
+    "content-hash": "eddb0106d2a623def6c98f8a3409de38",
     "packages": [],
     "packages-dev": [
         {
@@ -420,16 +420,16 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "6.0.1",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "bcfb2a1e2cbff14df8d6f3fb9cc12a4c3bb369d4"
+                "reference": "05aa763090b7dddc79d152b94852fbce73775d01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/bcfb2a1e2cbff14df8d6f3fb9cc12a4c3bb369d4",
-                "reference": "bcfb2a1e2cbff14df8d6f3fb9cc12a4c3bb369d4",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/05aa763090b7dddc79d152b94852fbce73775d01",
+                "reference": "05aa763090b7dddc79d152b94852fbce73775d01",
                 "shasum": ""
             },
             "require": {
@@ -443,14 +443,20 @@
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.3",
-                "symfony/var-dumper": "^7.3.5"
+                "phpunit/phpunit": "^13.1.3",
+                "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
             "extra": {
+                "thanks": {
+                    "url": "https://github.com/ghostwriter/container",
+                    "name": "ghostwriter/container"
+                },
                 "ghostwriter": {
                     "container": {
-                        "definition": "Ghostwriter\\Container\\Service\\Definition\\ContainerDefinition"
+                        "provider": [
+                            "Ghostwriter\\Container\\Service\\Provider\\ContainerProvider"
+                        ]
                     }
                 }
             },
@@ -461,7 +467,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -489,7 +495,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-18T05:56:22+00:00"
+            "time": "2026-04-13T19:15:02+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/container` dependency from `6.0.1` to `6.1.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`