### PR TITLE
Update boundwize/structarmed to version 0.7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.7.2",
+        "boundwize/structarmed": "^0.7.4",
         "ghostwriter/coding-standard": "dev-main",
         "ghostwriter/container": "^7.0.1",
         "mockery/mockery": "^1.6.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64af04c199ae35b0b831edb272d7c518",
+    "content-hash": "2629d8b92d85a220bfe39e344d4eabd8",
     "packages": [],
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.7.2",
+            "version": "0.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "e579d4f60501c0283ce164474eef6ddf93a38bc5"
+                "reference": "9e3216565e7d6f55ea63fbe3ed6082117228887f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/e579d4f60501c0283ce164474eef6ddf93a38bc5",
-                "reference": "e579d4f60501c0283ce164474eef6ddf93a38bc5",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9e3216565e7d6f55ea63fbe3ed6082117228887f",
+                "reference": "9e3216565e7d6f55ea63fbe3ed6082117228887f",
                 "shasum": ""
             },
             "require": {
@@ -71,7 +71,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.7.2"
+                "source": "https://github.com/boundwize/structarmed/tree/0.7.4"
             },
             "funding": [
                 {
@@ -79,7 +79,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T18:20:10+00:00"
+            "time": "2026-05-21T23:57:28+00:00"
         },
         {
             "name": "fidry/cpu-core-counter",
@@ -148,16 +148,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "3d40dad9488d6a309e9fbf7b969f44c4c28a3a99"
+                "reference": "6a490267228b3bdd902bc716dc8cb787af69db03"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/3d40dad9488d6a309e9fbf7b969f44c4c28a3a99",
-                "reference": "3d40dad9488d6a309e9fbf7b969f44c4c28a3a99",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/6a490267228b3bdd902bc716dc8cb787af69db03",
+                "reference": "6a490267228b3bdd902bc716dc8cb787af69db03",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.2",
+                "boundwize/structarmed": "^0.7.4",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -268,7 +268,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-21T20:29:23+00:00"
+            "time": "2026-05-22T02:16:14+00:00"
         },
         {
             "name": "ghostwriter/container",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.7.2` to `0.7.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`